### PR TITLE
Add two useful scripts for devs

### DIFF
--- a/scripts/rudder-dev/rudder-make-branch-from-ticket
+++ b/scripts/rudder-dev/rudder-make-branch-from-ticket
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import re
+import string
+
+import requests # apt-get install python-requests
+
+REDMINE_API_URL = "http://www.rudder-project.org/redmine"
+REDMINE_API_LIMIT = 100
+REDMINE_CLOSED_STATUSES = [5, 6, 16, 11]
+REDMINE_META_TRACKERS = [2, 3, 4]
+
+TRACKER_NAME_MAPPING = { 'Bug': 'bug', 'Implementation (development)': 'dev', 'Implementation (integration)': 'int' }
+
+def usage():
+  print "Usage: rudder-make-branch-from-ticket <ticket number>"
+
+def get_redmine_ticket(id):
+  tickets_req = requests.get(REDMINE_API_URL + "/issues/" + str(id) + ".json")
+  return tickets_req.json['issue'] if tickets_req.status_code == requests.codes.ok else None
+
+# Check arguments
+if len(sys.argv) != 2:
+  usage()
+  exit(1)
+
+ticket_id = sys.argv[1]
+
+print "Looking for Redmine ticket #" + str(ticket_id) + "... ",
+sys.stdout.flush() # to display previous unfinished line
+
+ticket = get_redmine_ticket(ticket_id)
+
+if not ticket:
+  print "Not found!"
+  print "***** ERROR: ticket not found. Exiting."
+  exit(2)
+
+print "Done"
+
+# Get ticket elements
+info = {}
+info['type'] = ticket['tracker']['name']
+info['name'] = ticket['subject']
+
+print "* Found " + info['type'] + " #" + str(ticket_id) + ": " + info['name']
+print "* URL: " + REDMINE_API_URL + "/issues/" + str(ticket_id)
+
+# Check ticket type
+if ticket['tracker'] in REDMINE_META_TRACKERS:
+  print "This is a meta-ticket! You cannot make a pull request on this ticket."
+  print "Create an implementation ticket (or requalify this ticket if appropriate)."
+  print "***** ERROR: This is a meta-ticket. Exiting."
+  exit(3)
+
+# Build branch name
+branchified_ticket_name = re.sub("__+", "_", re.sub("[^" + string.ascii_letters + string.digits + "]", "_", info['name'].strip().lower())).strip("_")
+branch_name = TRACKER_NAME_MAPPING[info['type']] + "_" + str(ticket_id) + "/" + branchified_ticket_name
+
+# Create the branch
+print "Creating branch " + branch_name
+os.system("git checkout -b " + branch_name)
+
+print ""
+print "When you're ready, run something like this:"
+print "git commit -am \"Fixes #""" + str(ticket_id) + ": " + info['name'].replace("\"", "\\\"") + "\""
+print "git push <your repo name, eg origin> " + branch_name
+
+print ""
+print "Then, you should be able to initiate a Pull Request from:"
+print "https://github.com/<your github username>/<repo-name>/"
+
+# TODO: Automate creating the pull request and match the branch to PR against from the target version in the Redmine ticket

--- a/scripts/rudder-dev/rudder-update-all-branches
+++ b/scripts/rudder-dev/rudder-update-all-branches
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -d ${PWD}/.git ]; then
+  echo "This doesn't appear to be a git repository. Exiting..."
+  exit 1
+fi
+
+BRANCHES="branches/rudder/2.4 branches/rudder/2.6 branches/rudder/2.7 branches/rudder/2.8 master"
+
+for branch in ${BRANCHES}; do
+  git checkout ${branch}
+  git pull
+done
+
+# Get all tags aswell
+git fetch --tags
+
+echo ""
+echo "If you are updating branches to perform a merge, you may run these commands:"
+echo "git checkout branches/rudder/2.6 && git merge branches/rudder/2.4"
+echo "git checkout branches/rudder/2.7 && git merge branches/rudder/2.6"
+echo "git checkout branches/rudder/2.8 && git merge branches/rudder/2.7"
+echo "git checkout master && git merge branches/rudder/2.8"


### PR DESCRIPTION
These are scripts I use when working with Rudder:
1. The first one, rudder-update-all-branches, is basically a shortcut for doing git checkout/git pull on all currently supported branches, and not forgetting to fetch tags, and reminding you of commands to run to do a merge.
2. The second one, rudder-make-branch-from-ticket, takes one argument that is a ticket ID from the Rudder Redmine. It will get that ticket, check it's type, and make a new git branch for you with the correct naming convention to make a pull request from, then remind you of the commands to run

Both can be significantly improved, and should be - feel free!
