### PR TITLE
Fixes #5257 - Set group for apache on /var/rudder/inventories/accepted-nodes-updates

### DIFF
--- a/scripts/rudder-multiserver-setup/rudder-relay-top.sh
+++ b/scripts/rudder-multiserver-setup/rudder-relay-top.sh
@@ -36,7 +36,7 @@ do
   mkdir -p ${i}
   chmod -R 1770 ${i}
   for group in apache www-data www; do
-    if getent group ${group} > /dev/null; then chown -R root:${group} /var/rudder/inventories/incoming; break; fi
+    if getent group ${group} > /dev/null; then chown -R root:${group} ${i}; break; fi
   done
 done
 


### PR DESCRIPTION
Fixes #5257 - Set group for apache on /var/rudder/inventories/accepted-nodes-updates

cf http://www.rudder-project.org/redmine/issues/5257
