### PR TITLE
Fixes #5361 - Simplify repo-merge.sh by using function instead of duplicated code

### DIFF
--- a/scripts/repo-merge.sh
+++ b/scripts/repo-merge.sh
@@ -30,23 +30,23 @@ export EMAIL_RECIPIENT="rudder@normation.com"
 export ERROR_SPOTTED=0
 
 # Parameters:
-#	${1} : Repository name
-#	${2} : Error type
+#  ${1} : Repository name
+#  ${2} : Error type
 
 function report_error {
 
-	REPO_NAME=${1}
-	ERROR_NAME=${2}
+  REPO_NAME=${1}
+  ERROR_NAME=${2}
 
-	export FINAL_REPORT="${FINAL_REPORT}Repository ${REPO_NAME}: ${ERROR_NAME} failure\n"
-	export ERROR_SPOTTED=1
+  export FINAL_REPORT="${FINAL_REPORT}Repository ${REPO_NAME}: ${ERROR_NAME} failure\n"
+  export ERROR_SPOTTED=1
 }
 
 # merge_repo() will merge a SRC_BRANCH_NAME into TARGET_BRANCH_NAME
 # Parameters:
-#   REPO_PATH:          Repository to be merged
-#   SRC_BRANCH_NAME:    Name of lower branch to be merged (i.e '2.10')
-#   TARGET_BRANCH_NAME: Name of higher branch to merge (i.e '2.11')
+#  REPO_PATH:          Repository to be merged
+#  SRC_BRANCH_NAME:    Name of lower branch to be merged (i.e '2.10')
+#  TARGET_BRANCH_NAME: Name of higher branch to merge (i.e '2.11')
 function merge_repo {
   # Set variables for function which will determine the complete name of branch
   local SRC_BRANCH=branches/rudder/${SRC_BRANCH_NAME}
@@ -87,26 +87,26 @@ echo ""
 for i in $REPOS
 do
 
-	cd $TEMPDIR
-    # Get repository to merge
-	git clone git@github.com:Normation/$i.git >/dev/null 2>&1
-	if [ $? -ne 0 ]; then report_error ${i} "Clone"; continue; fi
-    REPO_PATH="${TEMPDIR}/${i}"
+  cd $TEMPDIR
+  # Get repository to merge
+  git clone git@github.com:Normation/$i.git >/dev/null 2>&1
+  if [ $? -ne 0 ]; then report_error ${i} "Clone"; continue; fi
+  REPO_PATH="${TEMPDIR}/${i}"
 
-    # Then merge branch 2.6 with branch 2.10
-    SRC_BRANCH_NAME="2.6"
-    TARGET_BRANCH_NAME="2.10"
-    merge_repo
+  # Then merge branch 2.6 with branch 2.10
+  SRC_BRANCH_NAME="2.6"
+  TARGET_BRANCH_NAME="2.10"
+  merge_repo
 
-	# Then merge branch 2.10 with branch 2.11
-    SRC_BRANCH_NAME="2.10"
-    TARGET_BRANCH_NAME="2.11"
-    merge_repo
+  # Then merge branch 2.10 with branch 2.11
+  SRC_BRANCH_NAME="2.10"
+  TARGET_BRANCH_NAME="2.11"
+  merge_repo
 
-	# Then merge branch 2.11 with branch master
-    SRC_BRANCH_NAME="2.11"
-    TARGET_BRANCH_NAME="master"
-    merge_repo
+  # Then merge branch 2.11 with branch master
+  SRC_BRANCH_NAME="2.11"
+  TARGET_BRANCH_NAME="master"
+  merge_repo
 
 done
 
@@ -116,7 +116,7 @@ FINAL_REPORT="${FINAL_REPORT}\nYou may want to resolve the conflicts manually.\n
 
 if [ "${ERROR_SPOTTED}" -ne 0 ]
 then
-	/bin/echo -e "${FINAL_REPORT}" |mail -s "Automatic merging script on $(hostname --fqdn)" "${EMAIL_RECIPIENT}" -- -f noreply@normation.com
+  /bin/echo -e "${FINAL_REPORT}" |mail -s "Automatic merging script on $(hostname --fqdn)" "${EMAIL_RECIPIENT}" -- -f noreply@normation.com
 fi
 
 echo ""


### PR DESCRIPTION
Fixes #5361 - Simplify repo-merge.sh by using function instead of duplicated code

cf http://www.rudder-project.org/redmine/issues/5361
