### PR TITLE
Fixes for ansible inventory plugin

### DIFF
--- a/scripts/ansible/rudder.ini
+++ b/scripts/ansible/rudder.ini
@@ -5,7 +5,7 @@
 
 # Your Rudder server API URL, typically:
 # https://rudder.local/rudder/api
-uri = https://127.0.0.1:8381/rudder/api
+uri = https://rudder.local/rudder/api
 
 # By default, Rudder uses a self-signed certificate. Set this to True
 # to disable certificate validation.


### PR DESCRIPTION
* Fixed and homogenized formatting
* Renamed rudder_id to rudder_group_id and rudder_node_id to have access to both
* Fixed a bug in node loop
* Manage the case where the `/nodes` call returns no properties (before Rudder 3.0) to make the plugin compatible with all supported version of Rudder

Also did some testing with ansible, everything seems ok:

```bash
$ ansible -i rudder.py webservers -a "echo debug: {{rudder_node_id}} {{rudder_group_id}}  {{utf_8_poetry}}"
server.normation.com | success | rc=0 >>
debug: root 0268cb76-59bc-4f3f-8db4-866c71953902 testéÀ
```