### PR TITLE
Fixes #8378: rudder-dev cleanup fails if a remote branch doesn't exist

### DIFF
--- a/scripts/rudder-dev/rudder-dev-src
+++ b/scripts/rudder-dev/rudder-dev-src
@@ -1505,7 +1505,7 @@ def cleanup(more=False, dry=False):
         print("removing: " + branch)
         if not dry:
           shell("git branch -d " + branch, "Deleting local " + branch)
-          shell("git push " + OWN_REPOSITORY + " --delete " + branch, "Deleting remote " + branch)
+          shell("git push " + OWN_REPOSITORY + " --delete " + branch, "Deleting remote " + branch, fail_exit=False)
       else:
         print("keeping: " + branch)
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8378