### PR TITLE
Fixes #8468: Mark Rudder 3.0 as EOL in release-info

### DIFF
--- a/release-data/rudder-3.0.cson
+++ b/release-data/rudder-3.0.cson
@@ -5,7 +5,7 @@ release = "3.0"
 released = true
 
 # Is this version currently supported?
-supported = true
+supported = false
 
 # Has this version had Long-Term Support (LTS)?
 lts = false


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8468