### PR TITLE
Fixes #8977: Drop Ubuntu 12.04 server support in 4.0

### DIFF
--- a/release-data/rudder-4.0.cson
+++ b/release-data/rudder-4.0.cson
@@ -42,7 +42,7 @@ roles = {
           "debian-7":     [ "agent-allinone", "agent-thin", "relay", "server" ],
           "debian-8":     [ "agent-allinone", "agent-thin", "relay", "server" ],
           "ubuntu-10.04": [ "agent-allinone", "agent-thin", "relay" ],
-          "ubuntu-12.04": [ "agent-allinone", "agent-thin", "relay", "server" ],
+          "ubuntu-12.04": [ "agent-allinone", "agent-thin", "relay" ],
           "ubuntu-12.10": [ "agent-allinone", "agent-thin", "relay" ],
           "ubuntu-14.04": [ "agent-allinone", "agent-thin", "relay", "server" ],
           "ubuntu-16.04": [ "agent-allinone", "agent-thin", "relay", "server" ],


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8977