### PR TITLE
Fixes #8992: Mark Rudder 2.11 as EOL in release-data

### DIFF
--- a/release-data/rudder-2.11.cson
+++ b/release-data/rudder-2.11.cson
@@ -5,7 +5,7 @@ release = "2.11"
 released = true
 
 # Is this version currently supported?
-supported = true
+supported = false
 
 # 17th July 2014
 release-date = "2014-07-17"


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8992