### PR TITLE
Fixes #9490: Rudder-release build fails on 4.0 because of solaris and freebsd and build agent on sles12 

### DIFF
--- a/release-data/rudder-4.0.cson
+++ b/release-data/rudder-4.0.cson
@@ -31,8 +31,6 @@ architectures = {
                   "sles-11"   :   [ "i386", "amd64" ],
                   "sles-12"   :   [ "amd64" ],
                   "aix-5":        [ "ppc" ],
-                  "solaris-10":   [ "i386" ],
-                  "freebsd":      [ "i386", "amd64" ],
                 }
 
 # Roles are package groups
@@ -55,8 +53,6 @@ roles = {
           "sles-11":      [ "agent-allinone", "agent-thin", "relay", "server" ],
           "sles-12":      [ "agent-allinone", "agent-thin", "relay" ],
           "aix-5":        [ "agent-allinone", "agent-thin", "relay" ],
-          "solaris-10":   [ "agent-allinone" ],
-          "freebsd":      [ "agent-thin" ],
         }
 
 # Packages that are built


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9490