### PR TITLE
Fixes #10560: Update changelog to state that Rudder 4.1 needs Java 1.8

### DIFF
--- a/release-data/changelogs/changelog-4.1.md
+++ b/release-data/changelogs/changelog-4.1.md
@@ -31,6 +31,8 @@ We also recommend using the [Rudder
 Vagrant](https://github.com/Normation/rudder-vagrant) config if you want
 a quick and easy way to get an installation for testing.
 
+**IMPORTANT:** Rudder 4.1 requires Java RE (version 8 at least)
+
 **Operating systems supported**
 
 This version provides packages for these operating systems:


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10560