### PR TITLE
Fixes #12540: Stop support of rudder relay 4.1 on ubuntu 12.04

### DIFF
--- a/release-data/rudder-4.1.cson
+++ b/release-data/rudder-4.1.cson
@@ -46,7 +46,7 @@ roles = {
           "debian-8":     [ "agent-allinone", "agent-thin", "relay", "server" ],
           "debian-9":     [ "agent-allinone", "agent-thin", "relay", "server" ],
           "ubuntu-10.04": [ "agent-allinone" ],
-          "ubuntu-12.04": [ "agent-allinone", "agent-thin", "relay" ],
+          "ubuntu-12.04": [ "agent-allinone" ],
           "ubuntu-12.10": [ "agent-allinone" ],
           "ubuntu-14.04": [ "agent-allinone", "agent-thin", "relay", "server" ],
           "ubuntu-16.04": [ "agent-allinone", "agent-thin", "relay", "server" ],


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12540