### PR TITLE
Fixes #12778: missing ubuntu 18.04 codename in release data

### DIFF
--- a/release-data/systems.cson
+++ b/release-data/systems.cson
@@ -32,7 +32,8 @@ ubuntu = {
     "15.10": "wily",
     "16.04": "xenial",
     "16.10": "yakkety",
-    "17.04": "zesty"
+    "17.04": "zesty",
+    "18.04": "bionic"
   }
 }
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12778