### PR TITLE
Fixes #13293: Missing Ubuntu 18.04 arch in release-data

### DIFF
--- a/release-data/rudder-5.0.cson
+++ b/release-data/rudder-5.0.cson
@@ -19,6 +19,7 @@ architectures = {
                   "ubuntu-12.04": [ "i386", "amd64" ],
                   "ubuntu-14.04": [ "i386", "amd64" ],
                   "ubuntu-16.04": [ "i386", "amd64" ],
+                  "ubuntu-18.04": [ "amd64" ],
                   "rhel-3":       [ "i386", "amd64" ],
                   "rhel-5":       [ "i386", "amd64" ],
                   "rhel-6":       [ "i386", "amd64" ],


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13293