### PR TITLE
Fix error when starting service

### DIFF
--- a/scripts/rudder-setup/lib.sh
+++ b/scripts/rudder-setup/lib.sh
@@ -81,7 +81,7 @@ service_cmd() {
   then
     name="$1"
     shift
-    cmd="$2"
+    cmd="$1"
     shift
     systemctl "${cmd}" "${name}" "$@"
   else


### PR DESCRIPTION
**Problem**

When installing rudder-agent on ubuntu 18.04, the setup executes, at the end of the flow, the command

    service_cmd rudder-agent start

This fires

```
service_cmd() {
  if [ -x "/etc/init.d/$1" ]
  then
    name="$1"
    shift
    "/etc/init.d/${name}" "$@"
  elif type systemctl >/dev/null 2>/dev/null
  then
    name="$1"
    shift
    cmd="$2"
    shift
    systemctl "${cmd}" "${name}" "$@"
  else
    service "$@"
  fi
}
```

The system do:
```
   name="$1"
    shift
    cmd="$2"
    shift
    systemctl "${cmd}" "${name}" "$@"

```

The problem is due to calling it as

    service_cmd rudder-agent start

So 
   
   $1 = rudder-agent
   $2 = start

After this

    name="rudder-agent"
    shift

We have
  
    $1 = start    
    no $2 defined

So 
    
    cmd=""

So 

      service_cmd rudder-agent start

became

     systemctl "rudder-agent"

and execution stops

> Unknown operation .

**Proposed solution**

Simply changed from `$2` to `$1` after first `shift`