### PR TITLE
Fixes #14324: rudder-setup does use same apt file than rudder-agent

### DIFF
--- a/scripts/rudder-setup/add-repo.sh
+++ b/scripts/rudder-setup/add-repo.sh
@@ -51,7 +51,7 @@ add_repo() {
   then
     # Debian / Ubuntu like
    get - "https://repository.rudder.io/apt/rudder_apt_key.pub" | apt-key add -
-    cat > /etc/apt/sources.list.d/rudder-apt.list << EOF
+    cat > /etc/apt/sources.list.d/rudder.list << EOF
 deb ${URL_BASE}/ ${OS_CODENAME} main
 EOF
     apt-get update
@@ -100,7 +100,7 @@ EOF
 remove_repo() {
   if [ "${PM}" = "apt" ]
   then
-    rm -f /etc/apt/sources.list.d/rudder-apt.list
+    rm -f /etc/apt/sources.list.d/rudder.list
   elif [ "${PM}" = "yum" ]
   then
     rm -f /etc/yum.repos.d/rudder.repo


### PR DESCRIPTION
https://issues.rudder.io/issues/14324