### PR TITLE
Fixes #14948: ncf-setup can not install testinfra on ubuntu14 because of six conflict

### DIFF
--- a/scripts/rudder-setup/setup-ncf.sh
+++ b/scripts/rudder-setup/setup-ncf.sh
@@ -34,8 +34,8 @@ setup_ncf() {
     ${PM_INSTALL} python
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
     python get-pip.py
-    pip install -U six
-    pip install -U testinfra
+    pip install -U six || /bin/true
+    pip install -U testinfra --ignore-installed six
   fi
 
 


### PR DESCRIPTION
https://issues.rudder.io/issues/14948