### PR TITLE
Fixes #16056: Re-enabled rudder-api-client in 5.0

### DIFF
--- a/release-data/rudder-5.0.cson
+++ b/release-data/rudder-5.0.cson
@@ -91,7 +91,7 @@ tier1 = [
 packages = { 
              "agent-allinone": [ "rudder-agent" ],
              "relay":          [ "rudder-server-relay" ],
-             "server":         [ "rudder-inventory-ldap", "rudder-inventory-endpoint", "rudder-jetty", "rudder-reports", "rudder-server-root", "rudder-webapp", "rudder-techniques", "ncf", "ncf-api-virtualenv" ],
+             "server":         [ "rudder-inventory-ldap", "rudder-inventory-endpoint", "rudder-jetty", "rudder-reports", "rudder-server-root", "rudder-webapp", "rudder-techniques", "ncf", "ncf-api-virtualenv", "rudder-api-client" ],
            }
 
 # Packages that are architecture dependent (others are independent)


### PR DESCRIPTION
https://issues.rudder.io/issues/16056