### PR TITLE
Fixes #16548: Skip AWS extension if /sys/hypervisor/uuid does not exist

### DIFF
--- a/contrib/inventory-hooks/aws.py
+++ b/contrib/inventory-hooks/aws.py
@@ -32,7 +32,7 @@ def is_ec2():
             if f.read(3).lower() != "ec2":
                 return False
     except:
-        pass
+        return False
     return requests.get(METAURL).status_code == 200
 
 def load():


### PR DESCRIPTION
https://issues.rudder.io/issues/16548