### PR TITLE
Fixes #17117: rudder-api-client is not built on 6.1

### DIFF
--- a/release-data/rudder-6.1.cson
+++ b/release-data/rudder-6.1.cson
@@ -84,7 +84,7 @@ tier1 = [
 packages = { 
              "agent-allinone": [ "rudder-agent" ],
              "relay":          [ "rudder-server-relay" ],
-             "server":         [ "rudder-reports", "rudder-server-root", "rudder-webapp" ],
+             "server":         [ "rudder-reports", "rudder-server-root", "rudder-webapp", "rudder-api-client" ],
            }
 
 # Packages that are architecture dependent (others are independent)


### PR DESCRIPTION
https://issues.rudder.io/issues/17117