### PR TITLE
Fixes #17204: Remove ubuntu 16 as a rudder server in 6.1

### DIFF
--- a/release-data/changelogs/6.1/index.adoc
+++ b/release-data/changelogs/6.1/index.adoc
@@ -50,7 +50,7 @@ https://docs.rudder.io/reference/6.1/installation/server/sles.html[SLES]
 This version provides packages for these operating systems:
 
 * Rudder server and Rudder relay: *Debian 9-10, RHEL/CentOS 7-8 (64 bits),
-SLES 12-15, Ubuntu 16.04 LTS-18.04 LTS*
+SLES 12-15, Ubuntu 18.04 LTS*
 * Rudder agent: all of the above plus *Debian 8, RHEL/CentOS 6, Ubuntu 14.04 LTS*
 * Rudder agent (binary packages available with a https://www.rudder.io/en/pricing/subscription/[subscription]) : *Debian 5-7, RHEL/CentOS 3-5,
 SLES 10-11, Ubuntu 10.04 LTS-12.04 LTS-13.04-15.10, Windows Server 2008R2-2016, AIX

--- a/release-data/rudder-6.1.cson
+++ b/release-data/rudder-6.1.cson
@@ -54,7 +54,7 @@ roles = {
           "ubuntu-13.04":   [ "agent-allinone" ],
           "ubuntu-14.04":   [ "agent-allinone" ],
           "ubuntu-15.10":   [ "agent-allinone" ],
-          "ubuntu-16.04":   [ "agent-allinone", "relay", "server" ],
+          "ubuntu-16.04":   [ "agent-allinone" ],
           "ubuntu-18.04":   [ "agent-allinone", "relay", "server" ],
           "rhel-5":         [ "agent-allinone" ],
           "rhel-6":         [ "agent-allinone" ],


### PR DESCRIPTION
https://issues.rudder.io/issues/17204