### PR TITLE
Fixes #17270: Upgrade link in 6.1 changelog is wrong

### DIFF
--- a/release-data/changelogs/6.1/index.adoc
+++ b/release-data/changelogs/6.1/index.adoc
@@ -69,7 +69,7 @@ This is still a development version, it should not be used on production systems
 * Install docs for https://docs.rudder.io/reference/6.1/installation/server/debian.html[Debian/Ubuntu],
 https://docs.rudder.io/reference/6.1/installation/server/rhel.html[RHEL/centOS] and 
 https://docs.rudder.io/reference/6.1/installation/server/sles.html[SLES]
-* https://docs.rudder.io/reference/6.1/installation/upgrade.html[Upgrade nodes and doc]
+* https://docs.rudder.io/reference/6.1/installation/upgrade/notes.html[Upgrade nodes and doc]
 * https://docs.rudder.io/reference/6.1/installation/versions.html#_versions[Download links]
 
 == Supported operating systems


### PR DESCRIPTION
https://issues.rudder.io/issues/17270