### PR TITLE
Fixes #17754: Rudder-setup fails to set the correct repository on a sles15 system if lsb-release is installed

### DIFF
--- a/scripts/rudder-setup/detect-os.sh
+++ b/scripts/rudder-setup/detect-os.sh
@@ -132,6 +132,7 @@ detect_os() {
     Amazon) OS_COMPATIBLE="RHEL"
             OS_COMPATIBLE_VERSION=6;;
     SuSE)   OS_COMPATIBLE="SLES" ;;
+    SUSE)   OS_COMPATIBLE="SLES" ;;
     "SLES") OS_COMPATIBLE="SLES" ;;
     "SUSE LINUX")   OS_COMPATIBLE="SLES" ;;
   esac


### PR DESCRIPTION
https://issues.rudder.io/issues/17754