### PR TITLE
Fixes #18089: In ncf-setup, tests dependencies installation should not be under set -e

### DIFF
--- a/scripts/rudder-setup/test-ncf.sh
+++ b/scripts/rudder-setup/test-ncf.sh
@@ -10,6 +10,7 @@ test_ncf() {
 }
 
 install_test_dependencies() {
+    set +e
     TEST_DEPENDENCIES="htop python-jinja2 ntp acl python3 python3-jinja2 augeas augeas-tools augeas"
     SLES_DEPENDENCIES="dos2unix createrepo createrepo_c acl"
     # Install dependencies
@@ -25,10 +26,10 @@ install_test_dependencies() {
 
     # Install dependencies
     ${PM_UPDATE}
-    DEPS=${TEST_DEPENDENCIES}
+    DEPS="${TEST_DEPENDENCIES}"
     if [ "${OS_NAME}" = "SuSE" ] || [ "${OS_COMPATIBLE}" = "SLES" ];
     then
-      DEPS=${SLES_DEPENDENCIES} ${DEPS}
+      DEPS="${SLES_DEPENDENCIES} ${DEPS}"
     fi
 
     for package in ${DEPS}; do
@@ -44,4 +45,5 @@ install_test_dependencies() {
       pip install -U six || /bin/true
       pip install -U testinfra --ignore-installed six || /bin/true
     fi
+    set -e
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/18089