### PR TITLE
Fixes #19991: ncf-setup fails to install pytest on centos8

### DIFF
--- a/scripts/rudder-setup/test-ncf.sh
+++ b/scripts/rudder-setup/test-ncf.sh
@@ -16,7 +16,7 @@ test_ncf() {
 
 install_test_dependencies() {
     set +e
-    TEST_DEPENDENCIES="htop python-jinja2 ntp acl python3 python3-jinja2 augeas augeas-tools augeas"
+    TEST_DEPENDENCIES="htop python-jinja2 ntp acl python3 python3-jinja2 augeas augeas-tools augeas python3-pytest"
     SLES_DEPENDENCIES="dos2unix createrepo createrepo_c acl"
     # Install dependencies
     ${PM_UPDATE}


### PR DESCRIPTION
https://issues.rudder.io/issues/19991