### PR TITLE
Fixes #20448: rudder-setup restarts rudder-jetty directly after install to set password , and it's usually during inventory tratment

### DIFF
--- a/scripts/rudder-setup/setup-server.sh
+++ b/scripts/rudder-setup/setup-server.sh
@@ -138,6 +138,8 @@ set_admin() {
       details="<user name=\"admin\" password=\"${hash}\" role=\"administrator\" />"
       sed -i "/^[[:space:]]*<\/authentication>/i ${details}" "/opt/rudder/etc/rudder-users.xml"
       systemctl restart rudder-jetty
+      # force an inventory, because this restart often happens while inventory is being processed
+      rudder agent inventory
     fi
   fi
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/20448