### PR TITLE
Fixes #21680: rudder-setup should install plugins using --nightly when installing a nightly webapp build

### DIFF
--- a/scripts/rudder-setup/setup-server.sh
+++ b/scripts/rudder-setup/setup-server.sh
@@ -103,7 +103,7 @@ EOF
     fi
 
     # install plugins
-    if [ "${PLUGINS_VERSION}" = "nightly" ]; then
+    if [ "${PLUGINS_VERSION}" = "nightly" ] || echo "${RUDDER_VERSION}" | grep -q nightly ; then
       nightly_plugins="--nightly"
     fi
     for p in ${PLUGINS}


### PR DESCRIPTION
https://issues.rudder.io/issues/21680