### PR TITLE
Fixes #22014: rudder-setup fails to setup provate repo on debian -  invalid passwotd format

### DIFF
--- a/scripts/rudder-setup/add-repo.sh
+++ b/scripts/rudder-setup/add-repo.sh
@@ -86,8 +86,7 @@ EOF
         AUTH_CONF="/etc/apt/auth.conf.d/rudder.conf"
       fi
 
-      URLENCODED_PASSWORD=$(echo "${DOWNLOAD_PASSWORD}" | xxd -plain | tr -d '\n' | sed 's/\(..\)/%\1/g')
-      echo "machine download.rudder.io login ${DOWNLOAD_USER} password ${URLENCODED_PASSWORD}" >> "${AUTH_CONF}"
+      echo "machine download.rudder.io login ${DOWNLOAD_USER} password ${DOWNLOAD_PASSWORD}" >> "${AUTH_CONF}"
       chmod 640 ${AUTH_CONF}
     fi
 


### PR DESCRIPTION
https://issues.rudder.io/issues/22014