### PR TITLE
Fixes #24711: Missing message when merge was ok breaks plugin upmerge using rudder-dev (at least on private plugins repo)

### DIFF
--- a/scripts/rudder-dev/rudder-dev-src
+++ b/scripts/rudder-dev/rudder-dev-src
@@ -1290,7 +1290,7 @@ def merge_branch(old, new, strategy=None, automatic=False, dsc_version="", test=
     opts = ""
     if automatic:
       opts += " --no-edit "
-    shell(" git diff --quiet && git diff --quiet --staged || git commit "+opts, "Commiting")
+    shell(" git diff --quiet && git diff --quiet --staged || git commit -m 'Update submodules' "+opts, "Commiting")
   # run merge tests if there are some
   if run_tests:
     toplevel = shell("git rev-parse --show-toplevel", keep_output=True).strip()


### PR DESCRIPTION
https://issues.rudder.io/issues/24711