### PR TITLE
Fixes #25566: Use old RPM key in 8.2

### DIFF
--- a/scripts/rudder-setup/add-repo.sh
+++ b/scripts/rudder-setup/add-repo.sh
@@ -74,7 +74,7 @@ add_repo() {
 
   RELEASE_GPG_KEY="http${S}://repository.rudder.io/rudder_release_key"
   # RPM may use an old gpg key on old versions
-  if is_version_valid "${RUDDER_VERSION}" "[8.2 *]"
+  if is_version_valid "${RUDDER_VERSION}" "[8.3 *]"
   then
     RPM_GPG_KEY="${RELEASE_GPG_KEY}.pub"
   else


### PR DESCRIPTION
https://issues.rudder.io/issues/25566