### PR TITLE
Fixes #27353: Remove Ubuntu 16.04 from 9.0

### DIFF
--- a/release-data/rudder-9.0.cson
+++ b/release-data/rudder-9.0.cson
@@ -19,7 +19,6 @@ architectures = {
                   "debian-10":      [ "i386", "amd64", "armhf", "arm64" ],
                   "debian-11":      [ "i386", "amd64", "armhf", "arm64" ],
                   "debian-12":      [ "i386", "amd64", "armhf", "arm64" ],
-                  "ubuntu-16.04":   [ "i386", "amd64" ],
                   "ubuntu-18.04":   [ "amd64" ],
                   "ubuntu-20.04":   [ "amd64" ],
                   "ubuntu-22.04":   [ "amd64" ],


### PR DESCRIPTION
https://issues.rudder.io/issues/27353